### PR TITLE
Introduce `fling-test` action

### DIFF
--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -30,12 +30,13 @@ runs:
         #JOB_ID=$(testflinger --server https://${{ inputs.server }} submit --quiet ${{ inputs.job }})
         #echo "job id: $JOB_ID"
         #echo "job_id=$JOB_ID" >> GITHUB_OUTPUT
-        echo "job_id=ABCDEFG" >> GITHUB_OUTPUT
+        echo "id=ABCDEFG"
+        echo "id=ABCDEFG" >> GITHUB_OUTPUT
 
     - name: Track the status of the job and mirror its exit status
       shell: bash
       run: |
-        echo ${{ steps.submit.outputs.job_id }}
+        echo ${{ steps.submit.outputs.id }}
         # poll
         #testflinger --server https://${{ inputs.server }} poll ${{ steps.submit.outputs.job_id }}
         # retrieve results

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -36,7 +36,7 @@ runs:
       run: |
         echo $JOB_ID
         # poll
-        testflinger --server https://${{ inputs.server }} poll $JOB_ID
+        PYTHONUNBUFFERED=1 testflinger --server https://${{ inputs.server }} poll $JOB_ID
         # retrieve results
         STATUS=$(testflinger --server https://${{ inputs.server }} results $JOB_ID | jq -er .test_status)
         echo "Test exit status: $STATUS"

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -21,15 +21,13 @@ runs:
       run: |
         nc -vz ${{ inputs.server }} 443
 
-    - name: Build job definition
+    - name: Verify job
       shell: bash
       run: |
-        echo "${{ inputs.job }}" | yq eval -P - > job.yaml
+        echo -e "Job received:\n{{ inputs.job }}"
+        JOB_FILE=${{ github.workspace }}/job.yaml
+        echo "${{ inputs.job }}" > $JOB_FILE
+        # echo "${{ inputs.job }}" | yq eval -P - > job.yaml
         # diagnostics
-        cat job.yaml
-
-    - name: Submit job to Testflinger and optionally poll
-      shell: bash
-      run: |
-        JOB_ID=$(testflinger --server https://${{ inputs.server }} submit --quiet job.yaml)
-        echo "job id: $JOB_ID"
+        echo "Job file to be submitted"
+        cat $JOB_FILE

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -31,5 +31,5 @@ runs:
     - name: Submit job to Testflinger and optionally poll
       shell: bash
       run: |
-        JOB_ID=$(testflinger --server ${{ inputs.server }} submit --quiet job.yaml)
+        JOB_ID=$(testflinger --server https://${{ inputs.server }} submit --quiet job.yaml)
         echo "job id: $JOB_ID"

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -36,8 +36,8 @@ runs:
       run: |
         echo $JOB_ID
         # poll
-        testflinger --server https://${{ inputs.server }} poll ${{ steps.submit.outputs.job_id }}
+        testflinger --server https://${{ inputs.server }} poll $JOB_ID
         # retrieve results
-        STATUS=$(testflinger --server https://${{ inputs.server }} results ${{ steps.submit.job_id }} | jq -er .test_status)
+        STATUS=$(testflinger --server https://${{ inputs.server }} results $JOB_ID | jq -er .test_status)
         echo "Test exit status: $STATUS"
         exit $STATUS

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -1,8 +1,8 @@
 name: Test-flinging
-description: Submit a job YAML to a Testflinger server
+description: Submit a job YAML file to a Testflinger server
 inputs:
   job:
-    description: "Job YAML string (see https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/job-schema/ for more info)"
+    description: "Path to a job file (see https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/job-schema/ for more info)"
     required: true
   server:
     description: The Testflinger server to use
@@ -13,20 +13,17 @@ runs:
   steps:
     - name: Install prerequisites
       shell: bash
-      run: |
-        sudo snap install testflinger-cli jq
+      run: sudo snap install testflinger-cli jq
 
     - name: Test connection to Testflinger server
       shell: bash
-      run: |
-        nc -vz ${{ inputs.server }} 443
+      run: nc -vz ${{ inputs.server }} 443
 
-    - name: "Display job"
+    - name: Display contents of job file (for verification)
       shell: bash
-      run: |
-        cat ${{ inputs.job }}
+      run: cat ${{ inputs.job }}
 
-    - name: "Submit job"
+    - name: Submit job to the Testflinger server
       id: submit
       shell: bash
       run: |
@@ -34,7 +31,7 @@ runs:
         echo "job id: $JOB_ID"
         echo "job_id=$JOB_ID" >> GITHUB_OUTPUT
 
-    - name: "Poll and exit with result status"
+    - name: Track the status of the job and mirror its exit status
       shell: bash
       run: |
         # poll

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -1,5 +1,5 @@
-name: "Test-flinging"
-description: "Submits a job YAML to a Testflinger server"
+name: Test-flinging
+description: Submit a job YAML to a Testflinger server
 inputs:
   job:
     description: "Job YAML string (see https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/job-schema/ for more info)"
@@ -7,27 +7,27 @@ inputs:
   server:
     description: The Testflinger server to use
     required: false
-    default: 'testflinger.canonical.com'
+    default: testflinger.canonical.com
 runs:
-  using: "composite"
+  using: composite
   steps:
     - name: Install prerequisites
       shell: bash
       run: |
-        sudo snap install yq testflinger-cli
+        sudo snap install testflinger-cli
 
-    - name: Test testflinger connection
+    - name: Test connection to Testflinger server
       shell: bash
       run: |
         nc -vz ${{ inputs.server }} 443
 
-    - name: Verify job
+    - name: "Display job"
       shell: bash
       run: |
-        echo -e "Job received:\n{{ inputs.job }}"
-        JOB_FILE=${{ github.workspace }}/job.yaml
-        echo "${{ inputs.job }}" > $JOB_FILE
+        echo ${{ inputs.job }}
+        #JOB_FILE=${{ github.workspace }}/job.yaml
+        #echo "${{ inputs.job }}" > $JOB_FILE
         # echo "${{ inputs.job }}" | yq eval -P - > job.yaml
         # diagnostics
-        echo "Job file to be submitted"
-        cat $JOB_FILE
+        #echo "Job file to be submitted"
+        #cat $JOB_FILE

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -27,16 +27,18 @@ runs:
       id: submit
       shell: bash
       run: |
-        JOB_ID=$(testflinger --server https://${{ inputs.server }} submit --quiet ${{ inputs.job }})
-        echo "job id: $JOB_ID"
-        echo "job_id=$JOB_ID" >> GITHUB_OUTPUT
+        #JOB_ID=$(testflinger --server https://${{ inputs.server }} submit --quiet ${{ inputs.job }})
+        #echo "job id: $JOB_ID"
+        #echo "job_id=$JOB_ID" >> GITHUB_OUTPUT
+        echo "job_id=ABCDEFG" >> GITHUB_OUTPUT
 
     - name: Track the status of the job and mirror its exit status
       shell: bash
       run: |
+        echo ${{ steps.submit.outputs.job_id }}
         # poll
-        testflinger --server https://${{ inputs.server }} poll ${{ steps.submit.outputs.job_id }}
+        #testflinger --server https://${{ inputs.server }} poll ${{ steps.submit.outputs.job_id }}
         # retrieve results
-        STATUS=$(testflinger --server https://${{ inputs.server }} results ${{ steps.submit.job_id }} | jq -er .test_status)
-        echo "Test exit status: $STATUS"
-        exit $STATUS
+        #STATUS=$(testflinger --server https://${{ inputs.server }} results ${{ steps.submit.job_id }} | jq -er .test_status)
+        #echo "Test exit status: $STATUS"
+        #exit $STATUS

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -25,9 +25,9 @@ runs:
       shell: bash
       run: |
         cat ${{ inputs.job }}
-        #JOB_FILE=${{ github.workspace }}/job.yaml
-        #echo "${{ inputs.job }}" > $JOB_FILE
-        # echo "${{ inputs.job }}" | yq eval -P - > job.yaml
-        # diagnostics
-        #echo "Job file to be submitted"
-        #cat $JOB_FILE
+
+    - name: "Submit job"
+      shell: bash
+      run: |
+        JOB_ID=$(testflinger --server https://${{ inputs.server }} submit --quiet ${{ inputs.job }})
+        echo "job id: $JOB_ID"

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -5,7 +5,11 @@ inputs:
     description: "Path to a job file (see https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/job-schema/ for more info)"
     required: true
   poll:
-    description: The Testflinger server to use
+    description: Specify if the submitted job should be tracked to completion
+    required: false
+    default: false
+  dry-run:
+    description: Specify if the job should really be submitted
     required: false
     default: false
   server:
@@ -28,6 +32,7 @@ runs:
       run: cat ${{ inputs.job }}
 
     - name: Submit job to the Testflinger server
+      if: inputs.dry-run != 'true'
       id: submit
       shell: bash
       run: |
@@ -36,7 +41,7 @@ runs:
         echo "JOB_ID=$JOB_ID" >> $GITHUB_ENV
 
     - name: Track the status of the job and mirror its exit status
-      if: inputs.poll == 'true'
+      if: inputs.poll == 'true' && inputs.dry-run != 'true'
       shell: bash
       run: |
         echo $JOB_ID

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -14,7 +14,7 @@ runs:
     - name: Install prerequisites
       shell: bash
       run: |
-        sudo snap install testflinger-cli
+        sudo snap install testflinger-cli jq
 
     - name: Test connection to Testflinger server
       shell: bash
@@ -27,7 +27,19 @@ runs:
         cat ${{ inputs.job }}
 
     - name: "Submit job"
+      id: submit
       shell: bash
       run: |
         JOB_ID=$(testflinger --server https://${{ inputs.server }} submit --quiet ${{ inputs.job }})
         echo "job id: $JOB_ID"
+        echo "job_id=$JOB_ID" >> GITHUB_OUTPUT
+
+    - name: "Poll and exit with result status"
+      shell: bash
+      run: |
+        # poll
+        testflinger --server https://${{ inputs.server }} poll ${{ steps.submit.job_id }}
+        # retrieve results
+        STATUS=$(testflinger --server https://${{ inputs.server }} results ${{ steps.submit.job_id }} | jq -er .test_status)
+        echo "Test exit status: $STATUS"
+        exit $STATUS

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -30,13 +30,12 @@ runs:
         #JOB_ID=$(testflinger --server https://${{ inputs.server }} submit --quiet ${{ inputs.job }})
         #echo "job id: $JOB_ID"
         #echo "job_id=$JOB_ID" >> GITHUB_OUTPUT
-        echo "id=ABCDEFG"
-        echo "id=ABCDEFG" >> GITHUB_OUTPUT
+        echo "JOB_ID=ABCDEFG" >> $GITHUB_ENV
 
     - name: Track the status of the job and mirror its exit status
       shell: bash
       run: |
-        echo ${{ steps.submit.outputs.id }}
+        echo $JOB_ID
         # poll
         #testflinger --server https://${{ inputs.server }} poll ${{ steps.submit.outputs.job_id }}
         # retrieve results

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -38,7 +38,7 @@ runs:
       shell: bash
       run: |
         # poll
-        testflinger --server https://${{ inputs.server }} poll ${{ steps.submit.job_id }}
+        testflinger --server https://${{ inputs.server }} poll ${{ steps.submit.outputs.job_id }}
         # retrieve results
         STATUS=$(testflinger --server https://${{ inputs.server }} results ${{ steps.submit.job_id }} | jq -er .test_status)
         echo "Test exit status: $STATUS"

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -1,12 +1,13 @@
-name: "Testflinger Submission"
-description: "Submits a  to the Testflinger job schema using YAML provision data"
+name: "Test-flinging"
+description: "Submits a job YAML to a Testflinger server"
 inputs:
-  job_queue:
-    description: "The queue to post the job to"
+  job:
+    description: "Job YAML string (see https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/job-schema/ for more info)"
     required: true
-  test_data:
-    description: "YAML string for the optional test phase (see https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/test-phases/#test for more info)"
+  server:
+    description: The Testflinger server to use
     required: false
+    default: 'testflinger.canonical.com'
 runs:
   using: "composite"
   steps:
@@ -18,19 +19,17 @@ runs:
     - name: Test testflinger connection
       shell: bash
       run: |
-        nc -vz testflinger.canonical.com 443
+        nc -vz ${{ inputs.server }} 443
 
     - name: Build job definition
       shell: bash
       run: |
-        cat << EOF > job_definition.yaml
-        job_queue: rpi4b1g-001
-        $(if [ -n "${{ inputs.test_data }}" ]; then echo "test_data:"; echo "${{ inputs.test_data }}" | yq eval -P - ; fi)
-        EOF
-        echo "Job definition created."
+        echo "${{ inputs.job }}" | yq eval -P - > job.yaml
+        # diagnostics
+        cat job.yaml
 
     - name: Submit job to Testflinger and optionally poll
       shell: bash
       run: |
-        JOB_ID=$(testflinger --server https://testflinger-staging.canonical.com submit -q job_definition.yaml)
-        echo "JOB_ID: $JOB_ID"
+        JOB_ID=$(testflinger --server ${{ inputs.server }} submit --quiet job.yaml)
+        echo "job id: $JOB_ID"

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -1,0 +1,36 @@
+name: "Testflinger Submission"
+description: "Submits a  to the Testflinger job schema using YAML provision data"
+inputs:
+  job_queue:
+    description: "The queue to post the job to"
+    required: true
+  test_data:
+    description: "YAML string for the optional test phase (see https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/test-phases/#test for more info)"
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - name: Install prerequisites
+      shell: bash
+      run: |
+        sudo snap install yq testflinger-cli
+
+    - name: Test testflinger connection
+      shell: bash
+      run: |
+        nc -vz testflinger.canonical.com 443
+
+    - name: Build job definition
+      shell: bash
+      run: |
+        cat << EOF > job_definition.yaml
+        job_queue: rpi4b1g-001
+        $(if [ -n "${{ inputs.test_data }}" ]; then echo "test_data:"; echo "${{ inputs.test_data }}" | yq eval -P - ; fi)
+        EOF
+        echo "Job definition created."
+
+    - name: Submit job to Testflinger and optionally poll
+      shell: bash
+      run: |
+        JOB_ID=$(testflinger submit -q --server https://testflinger-staging.canonical.com job_definition.yaml)
+        echo "JOB_ID: $JOB_ID"

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -24,7 +24,7 @@ runs:
     - name: "Display job"
       shell: bash
       run: |
-        echo ${{ inputs.job }}
+        cat ${{ inputs.job }}
         #JOB_FILE=${{ github.workspace }}/job.yaml
         #echo "${{ inputs.job }}" > $JOB_FILE
         # echo "${{ inputs.job }}" | yq eval -P - > job.yaml

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -27,18 +27,17 @@ runs:
       id: submit
       shell: bash
       run: |
-        #JOB_ID=$(testflinger --server https://${{ inputs.server }} submit --quiet ${{ inputs.job }})
-        #echo "job id: $JOB_ID"
-        #echo "job_id=$JOB_ID" >> GITHUB_OUTPUT
-        echo "JOB_ID=ABCDEFG" >> $GITHUB_ENV
+        JOB_ID=$(testflinger --server https://${{ inputs.server }} submit --quiet ${{ inputs.job }})
+        echo "job id: $JOB_ID"
+        echo "JOB_ID=$JOB_ID" >> $GITHUB_ENV
 
     - name: Track the status of the job and mirror its exit status
       shell: bash
       run: |
         echo $JOB_ID
         # poll
-        #testflinger --server https://${{ inputs.server }} poll ${{ steps.submit.outputs.job_id }}
+        testflinger --server https://${{ inputs.server }} poll ${{ steps.submit.outputs.job_id }}
         # retrieve results
-        #STATUS=$(testflinger --server https://${{ inputs.server }} results ${{ steps.submit.job_id }} | jq -er .test_status)
-        #echo "Test exit status: $STATUS"
-        #exit $STATUS
+        STATUS=$(testflinger --server https://${{ inputs.server }} results ${{ steps.submit.job_id }} | jq -er .test_status)
+        echo "Test exit status: $STATUS"
+        exit $STATUS

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -44,7 +44,6 @@ runs:
       if: inputs.poll == 'true' && inputs.dry-run != 'true'
       shell: bash
       run: |
-        echo $JOB_ID
         # poll
         PYTHONUNBUFFERED=1 testflinger --server https://${{ inputs.server }} poll $JOB_ID
         # retrieve results

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -4,6 +4,10 @@ inputs:
   job:
     description: "Path to a job file (see https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/job-schema/ for more info)"
     required: true
+  poll:
+    description: The Testflinger server to use
+    required: false
+    default: false
   server:
     description: The Testflinger server to use
     required: false
@@ -32,6 +36,7 @@ runs:
         echo "JOB_ID=$JOB_ID" >> $GITHUB_ENV
 
     - name: Track the status of the job and mirror its exit status
+      if: inputs.poll == 'true'
       shell: bash
       run: |
         echo $JOB_ID

--- a/.github/actions/fling-test/action.yaml
+++ b/.github/actions/fling-test/action.yaml
@@ -32,5 +32,5 @@ runs:
     - name: Submit job to Testflinger and optionally poll
       shell: bash
       run: |
-        JOB_ID=$(testflinger submit -q --server https://testflinger-staging.canonical.com job_definition.yaml)
+        JOB_ID=$(testflinger --server https://testflinger-staging.canonical.com submit -q job_definition.yaml)
         echo "JOB_ID: $JOB_ID"


### PR DESCRIPTION
Add the `fling-test` action for submitting Testflinger job files to a Testflinger server.

Here's an excerpt from the action definition that specifies the inputs it expects:
```
description: Submit a job YAML file to a Testflinger server
inputs:
  job:
    description: "Path to a job file (see https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/job-schema/ for more info)"
    required: true
  poll:
    description: Specify if the submitted job should be tracked to completion
    required: false
    default: false
  dry-run:
    description: Specify if the job should really be submitted
    required: false
    default: false
  server:
    description: The Testflinger server to use
    required: false
    default: testflinger.canonical.com
```
Here is an [example workflow (Checkbox canary test)](https://github.com/canonical/checkbox/blob/test-action-fling-test/.github/workflows/checkbox-canary-test.yaml) that uses this action to submit a job file.